### PR TITLE
getaddress.io API Changes

### DIFF
--- a/src/Getaddress.php
+++ b/src/Getaddress.php
@@ -48,7 +48,7 @@ class GetAddress
     public function lookup($postcode, $houseNumOrName = '')
     {
         try {
-            $response = $this->client->get(sprintf('%s/%s', $postcode, $houseNumOrName), ['auth' => ['api-key', $this->apiKey]]);
+            $response = $this->client->get('find/'.sprintf('%s/%s', $postcode, $houseNumOrName), ['auth' => ['api-key', $this->apiKey]]);
         } catch (RequestException $e) {
             if ($e->hasResponse() && $e->getResponse()->getStatusCode() == 401) {
                 throw new GetAddressAuthenticationFailedException();
@@ -76,11 +76,11 @@ class GetAddress
         $getAddressResponse = new GetAddressResponse();
 
         //Set the longitude and latitude fields
-        $getAddressResponse->setLongitude($responseObj->Longitude);
-        $getAddressResponse->setLatitude($responseObj->Latitude);
+        $getAddressResponse->setLongitude($responseObj->longitude);
+        $getAddressResponse->setLatitude($responseObj->latitude);
 
         //Set the address fields
-        foreach ($responseObj->Addresses as $addressLine) {
+        foreach ($responseObj->addresses as $addressLine) {
             $addressParts = explode(',', $addressLine);
             $getAddressResponse->addAddress(
                 new Address(


### PR DESCRIPTION
The API Provider has changed some information, such as a prefix on the URL and changed to capitalisation of the returned information causing the package as it is to be unuseable.